### PR TITLE
Fix error when changing case of a selection

### DIFF
--- a/plugin/caser.vim
+++ b/plugin/caser.vim
@@ -74,12 +74,11 @@ endfunction
 function! s:ActionSetup(fn)
   let s:encode_fn = a:fn
   let &opfunc = matchstr(expand('<sfile>'), '<SNR>\d\+_').'ActionOpfunc'
-  return 'g@'
 endfunction
 
 function! s:MapAction(fn, keys)
-  exe 'nnoremap <expr> <Plug>Caser'.a:fn.' <SID>ActionSetup("'.a:fn.'")'
-  exe 'xnoremap <expr> <Plug>CaserV'.a:fn.' <SID>DoAction("'.a:fn.'",visualmode())'
+  exe 'nnoremap <silent> <Plug>Caser'.a:fn.' :<C-U>call <SID>ActionSetup("'.a:fn.'")<CR>g@'
+  exe 'xnoremap <silent> <Plug>CaserV'.a:fn.' :<C-U>call <SID>DoAction("'.a:fn.'",visualmode())<CR>'
 
   if !exists('g:caser_no_mappings') || !g:caser_no_mappings
     for key in a:keys


### PR DESCRIPTION
Fixes #6, #8 

This change rolls back some of the refactors made in the previous commit. While the code could be cleaner, we no longer get error E523 when trying to change the case of a visual selection. The issue seems to be with the way `<expr>` was being used, but the specifics are still unclear.