### PR TITLE
Move functions to autoload

### DIFF
--- a/autoload/caser.vim
+++ b/autoload/caser.vim
@@ -1,5 +1,7 @@
 " This has been adapted from Tim Pope's amazing abolish.vim
 " <https://github.com/tpope/vim-abolish>
+
+" Case Handlers {{{
 function! caser#CamelCase(word)
   let word = substitute(a:word, '[ .-]', '_', 'g')
   if word !~# '_' && word =~# '\l'
@@ -49,3 +51,82 @@ endfunction
 function! caser#DotCase(word)
   return substitute(caser#SnakeCase(a:word), '_', '.', 'g')
 endfunction
+"}}}
+
+" Setup {{{
+
+" Adapted from unimpaired.vim by Tim Pope.
+function! caser#DoAction(fn, type)
+  " backup settings that we will change
+  let sel_save = &selection
+  let cb_save = &clipboard
+
+  " make selection and clipboard work the way we need
+  set selection=inclusive clipboard-=unnamed clipboard-=unnamedplus
+
+  " backup the unnamed register, which we will be yanking into
+  let reg_save = @@
+  let sel = ""
+
+  " yank the relevant text, and also set the visual selection (which will be reused if the text
+  " needs to be replaced)
+  if a:type =~ '^\d\+$'
+    " if type is a number, then select that many lines
+    let sel = 'V'.a:type.'$y'
+  elseif a:type =~ '^.$'
+    " if type is 'v', 'V', or '<C-V>' (i.e. 0x16) then reselect the visual region
+    let sel = "`<" . a:type . "`>y"
+  elseif a:type == 'line'
+    " line-based text motion
+    let sel = "'[V']y"
+  elseif a:type == 'block'
+    " block-based text motion
+    let sel = "`[\<C-V>`]y"
+  else
+    " char-based text motion
+    let sel = "`[v`]y"
+  endif
+
+  silent exe 'normal! ' . sel
+
+  " call the user-defined function, passing it the contents of the unnamed register
+  let repl = {"caser#".a:fn}(@@)
+
+  " if the function returned a value, then replace the text
+  if type(repl) == 1
+    " put the replacement text into the unnamed register, and also set it to be a
+    " characterwise, linewise, or blockwise selection, based upon the selection type of the
+    " yank we did above
+    call setreg('@', repl, getregtype('@'))
+
+    " reselect the visual region and paste
+    normal! gvp
+  endif
+
+  " restore saved settings and register value
+  let @@ = reg_save
+  let &selection = sel_save
+  let &clipboard = cb_save
+endfunction
+
+function! caser#ActionOpfunc(type)
+  return caser#DoAction(s:encode_fn, a:type)
+endfunction
+
+function! caser#ActionSetup(fn)
+  let s:encode_fn = a:fn
+  let &opfunc = matchstr(expand('<sfile>'), '\d\+_').'caser#ActionOpfunc'
+endfunction
+
+function! caser#MapAction(fn, keys)
+  exe 'nnoremap <silent> <Plug>Caser'.a:fn.' :<C-U>call caser#ActionSetup("'.a:fn.'")<CR>g@'
+  exe 'xnoremap <silent> <Plug>CaserV'.a:fn.' :<C-U>call caser#DoAction("'.a:fn.'",visualmode())<CR>'
+
+  if !exists('g:caser_no_mappings') || !g:caser_no_mappings
+    for key in a:keys
+      exe 'nmap '.g:caser_prefix.key.' <Plug>Caser'.a:fn
+      exe 'xmap '.g:caser_prefix.key.' <Plug>CaserV'.a:fn
+    endfor
+  endif
+endfunction
+" }}}

--- a/plugin/caser.vim
+++ b/plugin/caser.vim
@@ -4,99 +4,18 @@ endif
 let g:loaded_caser = 1
 
 " Defaults {{{
-
 if !exists('g:caser_prefix')
   let g:caser_prefix = 'gs'
 endif
 
+call caser#MapAction('MixedCase', ['m', 'p'])
+call caser#MapAction('CamelCase', ['c'])
+call caser#MapAction('SnakeCase', ['_'])
+call caser#MapAction('UpperCase', ['u', 'U'])
+call caser#MapAction('TitleCase', ['t'])
+call caser#MapAction('SentenceCase', ['s'])
+call caser#MapAction('SpaceCase', ['<space>'])
+call caser#MapAction('KebabCase', ['k', '-'])
+call caser#MapAction('TitleKebabCase', ['K'])
+call caser#MapAction('DotCase', ['.'])
 " }}}
-
-" Setup {{{
-
-" Adapted from unimpaired.vim by Tim Pope.
-function! s:DoAction(fn, type)
-  " backup settings that we will change
-  let sel_save = &selection
-  let cb_save = &clipboard
-
-  " make selection and clipboard work the way we need
-  set selection=inclusive clipboard-=unnamed clipboard-=unnamedplus
-
-  " backup the unnamed register, which we will be yanking into
-  let reg_save = @@
-  let sel = ""
-
-  " yank the relevant text, and also set the visual selection (which will be reused if the text
-  " needs to be replaced)
-  if a:type =~ '^\d\+$'
-    " if type is a number, then select that many lines
-    let sel = 'V'.a:type.'$y'
-  elseif a:type =~ '^.$'
-    " if type is 'v', 'V', or '<C-V>' (i.e. 0x16) then reselect the visual region
-    let sel = "`<" . a:type . "`>y"
-  elseif a:type == 'line'
-    " line-based text motion
-    let sel = "'[V']y"
-  elseif a:type == 'block'
-    " block-based text motion
-    let sel = "`[\<C-V>`]y"
-  else
-    " char-based text motion
-    let sel = "`[v`]y"
-  endif
-
-  silent exe 'normal! ' . sel
-
-  " call the user-defined function, passing it the contents of the unnamed register
-  let repl = {"caser#".a:fn}(@@)
-
-  " if the function returned a value, then replace the text
-  if type(repl) == 1
-    " put the replacement text into the unnamed register, and also set it to be a
-    " characterwise, linewise, or blockwise selection, based upon the selection type of the
-    " yank we did above
-    call setreg('@', repl, getregtype('@'))
-
-    " reselect the visual region and paste
-    normal! gvp
-  endif
-
-  " restore saved settings and register value
-  let @@ = reg_save
-  let &selection = sel_save
-  let &clipboard = cb_save
-endfunction
-
-function! s:ActionOpfunc(type)
-  return s:DoAction(s:encode_fn, a:type)
-endfunction
-
-function! s:ActionSetup(fn)
-  let s:encode_fn = a:fn
-  let &opfunc = matchstr(expand('<sfile>'), '<SNR>\d\+_').'ActionOpfunc'
-endfunction
-
-function! s:MapAction(fn, keys)
-  exe 'nnoremap <silent> <Plug>Caser'.a:fn.' :<C-U>call <SID>ActionSetup("'.a:fn.'")<CR>g@'
-  exe 'xnoremap <silent> <Plug>CaserV'.a:fn.' :<C-U>call <SID>DoAction("'.a:fn.'",visualmode())<CR>'
-
-  if !exists('g:caser_no_mappings') || !g:caser_no_mappings
-    for key in a:keys
-      exe 'nmap '.g:caser_prefix.key.' <Plug>Caser'.a:fn
-      exe 'xmap '.g:caser_prefix.key.' <Plug>CaserV'.a:fn
-    endfor
-  endif
-endfunction
-
-" }}}
-
-call s:MapAction('MixedCase', ['m', 'p'])
-call s:MapAction('CamelCase', ['c'])
-call s:MapAction('SnakeCase', ['_'])
-call s:MapAction('UpperCase', ['u', 'U'])
-call s:MapAction('TitleCase', ['t'])
-call s:MapAction('SentenceCase', ['s'])
-call s:MapAction('SpaceCase', ['<space>'])
-call s:MapAction('KebabCase', ['k', '-'])
-call s:MapAction('TitleKebabCase', ['K'])
-call s:MapAction('DotCase', ['.'])


### PR DESCRIPTION
Thank you very much for a very useful plugin!

**Why** is the change needed?

This is a very neat plugin with a very specific use-case. As such I see
it as a waste of resources to source multiple functions at vim start-up.
I am happy keeping this change in my fork, but I thought you might want
it in the main plugin as well.

**How** is the need addressed?

- Rename functions according to existing naming schema:
  - `s:ActionOpfunc` to `caser#ActionOpfunc`
  - `s:ActionSetup` to `caser#ActionSetup`
  - `s:MapAction` to `caser#MapAction`
  - `s:DoAction` to `caser#DoAction`
- Move them all to the autoload file, trying to reintroduce the same
  folding pattern as previously applied

**What** side effects could this cause?

- Maintainer would have to get used to the change
- The folds and naming might've been different if the maintainer had
  made the change