### PR TITLE
Preserve cursor after casing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+VIM ?= vim
+
+.PHONY: test
+test:
+	$(VIM) -Nu NONE -n -es -S test/cursor.vim

--- a/autoload/caser.vim
+++ b/autoload/caser.vim
@@ -56,65 +56,73 @@ endfunction
 " Setup {{{
 
 " Adapted from unimpaired.vim by Tim Pope.
-function! caser#DoAction(fn, type)
+function! caser#DoAction(fn, type, ...)
+  let view_save = a:0 ? a:1 : winsaveview()
+
   " backup settings that we will change
   let sel_save = &selection
   let cb_save = &clipboard
-
-  " make selection and clipboard work the way we need
-  set selection=inclusive clipboard-=unnamed clipboard-=unnamedplus
-
-  " backup the unnamed register, which we will be yanking into
   let reg_save = @@
-  let sel = ""
 
-  " yank the relevant text, and also set the visual selection (which will be reused if the text
-  " needs to be replaced)
-  if a:type =~ '^\d\+$'
-    " if type is a number, then select that many lines
-    let sel = 'V'.a:type.'$y'
-  elseif a:type =~ '^.$'
-    " if type is 'v', 'V', or '<C-V>' (i.e. 0x16) then reselect the visual region
-    let sel = "`<" . a:type . "`>y"
-  elseif a:type == 'line'
-    " line-based text motion
-    let sel = "'[V']y"
-  elseif a:type == 'block'
-    " block-based text motion
-    let sel = "`[\<C-V>`]y"
-  else
-    " char-based text motion
-    let sel = "`[v`]y"
-  endif
+  try
+    " make selection and clipboard work the way we need
+    set selection=inclusive clipboard-=unnamed clipboard-=unnamedplus
 
-  silent exe 'normal! ' . sel
+    let sel = ""
 
-  " call the user-defined function, passing it the contents of the unnamed register
-  let repl = {"caser#".a:fn}(@@)
+    " yank the relevant text, and also set the visual selection (which will be reused if the text
+    " needs to be replaced)
+    if a:type =~ '^\d\+$'
+      " if type is a number, then select that many lines
+      let sel = 'V'.a:type.'$y'
+    elseif a:type =~ '^.$'
+      " if type is 'v', 'V', or '<C-V>' (i.e. 0x16) then reselect the visual region
+      let sel = "`<" . a:type . "`>y"
+    elseif a:type == 'line'
+      " line-based text motion
+      let sel = "'[V']y"
+    elseif a:type == 'block'
+      " block-based text motion
+      let sel = "`[\<C-V>`]y"
+    else
+      " char-based text motion
+      let sel = "`[v`]y"
+    endif
 
-  " if the function returned a value, then replace the text
-  if type(repl) == 1
-    " put the replacement text into the unnamed register, and also set it to be a
-    " characterwise, linewise, or blockwise selection, based upon the selection type of the
-    " yank we did above
-    call setreg('@', repl, getregtype('@'))
+    silent exe 'normal! ' . sel
 
-    " reselect the visual region and paste
-    normal! gvp
-  endif
+    " call the user-defined function, passing it the contents of the unnamed register
+    let repl = {"caser#".a:fn}(@@)
 
-  " restore saved settings and register value
-  let @@ = reg_save
-  let &selection = sel_save
-  let &clipboard = cb_save
+    " if the function returned a value, then replace the text
+    if type(repl) == 1
+      " put the replacement text into the unnamed register, and also set it to be a
+      " characterwise, linewise, or blockwise selection, based upon the selection type of the
+      " yank we did above
+      call setreg('@', repl, getregtype('@'))
+
+      " reselect the visual region and paste
+      normal! gvp
+    endif
+
+  finally
+    " restore saved settings, register value, and cursor position
+    let @@ = reg_save
+    let &selection = sel_save
+    let &clipboard = cb_save
+    call winrestview(view_save)
+  endtry
 endfunction
 
 function! caser#ActionOpfunc(type)
-  return caser#DoAction(s:encode_fn, a:type)
+  let view_save = exists('s:view_save') ? s:view_save : winsaveview()
+  unlet! s:view_save
+  return caser#DoAction(s:encode_fn, a:type, view_save)
 endfunction
 
 function! caser#ActionSetup(fn)
   let s:encode_fn = a:fn
+  let s:view_save = winsaveview()
   let &opfunc = matchstr(expand('<sfile>'), '\d\+_').'caser#ActionOpfunc'
 endfunction
 

--- a/test/cursor.vim
+++ b/test/cursor.vim
@@ -1,0 +1,39 @@
+set nomore
+set rtp^=.
+runtime plugin/caser.vim
+
+function! s:finish() abort
+  if empty(v:errors)
+    qa!
+  endif
+
+  for error in v:errors
+    echom error
+  endfor
+  cquit
+endfunction
+
+function! s:new_buffer(lines, lnum, col) abort
+  enew!
+  call setline(1, a:lines)
+  call cursor(a:lnum, a:col)
+endfunction
+
+call s:new_buffer(['foo_bar baz_qux'], 1, 5)
+call caser#ActionSetup('CamelCase')
+normal! g@iw
+call assert_equal('fooBar baz_qux', getline(1), 'normal charwise changes selected word')
+call assert_equal([0, 1, 5, 0], getpos('.'), 'normal charwise preserves cursor')
+
+call s:new_buffer(['foo_bar', 'baz_qux'], 1, 3)
+call caser#ActionSetup('UpperCase')
+normal! g@j
+call assert_equal(['FOO_BAR', 'BAZ_QUX'], getline(1, 2), 'normal linewise changes selected lines')
+call assert_equal([0, 1, 3, 0], getpos('.'), 'normal linewise preserves cursor')
+
+call s:new_buffer(['foo_bar baz_qux'], 1, 1)
+normal v6lgsc
+call assert_equal('fooBar baz_qux', getline(1), 'visual mapping changes selected text')
+call assert_equal([0, 1, 1, 0], getpos('.'), 'visual mapping preserves cursor')
+
+call s:finish()


### PR DESCRIPTION
```markdown
## Summary

Fixes cursor jumps after applying casing transformations.

The operator flow was moving the cursor while selecting/yanking the target text and then leaving it at the pasted replacement. This now saves the original window view before the transformation and restores it afterward, covering both normal-mode operator usage and visual-mode mappings.

## Changes

- Preserve cursor/window view after casing transformations
- Restore temporary register/options state through a `try`/`finally` cleanup path
- Add a minimal Vim regression test suite
- Add `make test` for running the headless Vim tests